### PR TITLE
Added `Geo` namespace to `Gemstone.Numerics`

### DIFF
--- a/src/Gemstone.Numeric/Gemstone.Numeric.csproj
+++ b/src/Gemstone.Numeric/Gemstone.Numeric.csproj
@@ -61,6 +61,10 @@
     <PackageReference Include="Gemstone.Common" Version="1.0.128" Condition="'$(Configuration)'!='Development'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Geo\" />
+  </ItemGroup>
+
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <PropertyGroup Condition="'$(SIGNTOOL)' != ''">

--- a/src/Gemstone.Numeric/Gemstone.Numeric.csproj
+++ b/src/Gemstone.Numeric/Gemstone.Numeric.csproj
@@ -61,10 +61,6 @@
     <PackageReference Include="Gemstone.Common" Version="1.0.128" Condition="'$(Configuration)'!='Development'" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Geo\" />
-  </ItemGroup>
-
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <PropertyGroup Condition="'$(SIGNTOOL)' != ''">

--- a/src/Gemstone.Numeric/Geo/CoordinateReferenceSystem.cs
+++ b/src/Gemstone.Numeric/Geo/CoordinateReferenceSystem.cs
@@ -1,0 +1,133 @@
+﻿//******************************************************************************************************
+//  CoordinateReferenceSystem.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+#region [ Contributor License Agreements ]
+
+/*
+    Copyright (c) 2010-2016, Vladimir Agafonkin
+    Copyright (c) 2010-2011, CloudMade
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are
+    permitted provided that the following conditions are met:
+
+       1. Redistributions of source code must retain the above copyright notice, this list of
+          conditions and the following disclaimer.
+
+       2. Redistributions in binary form must reproduce the above copyright notice, this list
+          of conditions and the following disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#endregion
+
+using System;
+using Gemstone.Numeric.Analysis;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Abstract class that defines coordinate reference systems for projecting
+/// geographical points into pixel (screen) coordinates and back.
+/// </summary>
+/// <remarks>http://en.wikipedia.org/wiki/Coordinate_reference_system</remarks>
+public abstract class CoordinateReferenceSystem
+{
+    /// <summary>
+    /// Gets the projection used by the CRS.
+    /// </summary>
+    public abstract IProjection Projection { get; }
+
+    /// <summary>
+    /// Gets the transformation used by the CRS.
+    /// </summary>
+    public abstract Transformation Transformation { get; }
+
+    /// <summary>
+    /// Translates the given geographical coordinate
+    /// to a cartesian point at the given zoom level.
+    /// </summary>
+    /// <param name="coordinate">The coordinate to be translated.</param>
+    /// <param name="zoom">The zoom level.</param>
+    /// <returns>The cartesian point corresponding to the given coordinate.</returns>
+    public virtual Point Translate(GeoCoordinate coordinate, double zoom)
+    {
+        Point projectedPoint = Projection.Project(coordinate);
+        double scale = Scale(zoom);
+        return Transformation.Transform(projectedPoint, scale);
+    }
+
+    /// <summary>
+    /// Translates the given cartesian point to a
+    /// geographical coordinate at the given zoom level.
+    /// </summary>
+    /// <param name="point">The point to be translated.</param>
+    /// <param name="zoom">The zoom level.</param>
+    /// <returns>The geographical location of the point.</returns>
+    public virtual GeoCoordinate Translate(Point point, double zoom)
+    {
+        double scale = Scale(zoom);
+        Point untransformedPoint = Transformation.Untransform(point, scale);
+        return Projection.Unproject(untransformedPoint);
+    }
+
+    /// <summary>
+    /// Returns the scale used when transforming projected coordinates into
+    /// pixel coordinates for a particular zoom. For example, it returns
+    /// <c>256 * 2^zoom</c> for Mercator-based CRS.
+    /// </summary>
+    /// <param name="zoom">The zoom level.</param>
+    /// <returns>The scale at the given zoom level.</returns>
+    public virtual double Scale(double zoom)
+    {
+        return 256 * Math.Pow(2, zoom);
+    }
+
+    /// <summary>
+    /// Returns the zoom level corresponding to the given scale factor.
+    /// </summary>
+    /// <param name="scale">The scale factor.</param>
+    /// <returns>The zoom level corresponding to the given scale factor.</returns>
+    public virtual double Zoom(double scale)
+    {
+        return Math.Log(scale / 256) / Math.Log(2);
+    }
+
+    /// <summary>
+    /// Returns the distance between two geographical coordinates.
+    /// </summary>
+    /// <param name="coordinate1">The first geographical coordinate.</param>
+    /// <param name="coordinate2">The second geographical coordinate.</param>
+    /// <returns>The distance between two geographical coordinates.</returns>
+    public abstract double Distance(GeoCoordinate coordinate1, GeoCoordinate coordinate2);
+}

--- a/src/Gemstone.Numeric/Geo/EPSG3857.cs
+++ b/src/Gemstone.Numeric/Geo/EPSG3857.cs
@@ -1,0 +1,91 @@
+﻿//******************************************************************************************************
+//  EPSG3857.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+#region [ Contributor License Agreements ]
+
+/*
+    Copyright (c) 2010-2016, Vladimir Agafonkin
+    Copyright (c) 2010-2011, CloudMade
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are
+    permitted provided that the following conditions are met:
+
+       1. Redistributions of source code must retain the above copyright notice, this list of
+          conditions and the following disclaimer.
+
+       2. Redistributions in binary form must reproduce the above copyright notice, this list
+          of conditions and the following disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#endregion
+
+using System;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// The most common CRS for online maps.
+/// Uses Spherical Mercator projection.
+/// </summary>
+public class EPSG3857 : Earth
+{
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="EPSG3857"/> class.
+    /// </summary>
+    public EPSG3857()
+    {
+        const double XScale = 0.5D / (Math.PI * SphericalMercator.R);
+        Projection = new SphericalMercator();
+        Transformation = new Transformation(XScale, 0.5D, -XScale, 0.5D);
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the projection used by the CRS.
+    /// </summary>
+    public override IProjection Projection { get; }
+
+    /// <summary>
+    /// Gets the transformation used by the CRS.
+    /// </summary>
+    public override Transformation Transformation { get; }
+
+    #endregion
+}

--- a/src/Gemstone.Numeric/Geo/Earth.cs
+++ b/src/Gemstone.Numeric/Geo/Earth.cs
@@ -1,0 +1,92 @@
+﻿//******************************************************************************************************
+//  Earth.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+#region [ Contributor License Agreements ]
+
+/*
+    Copyright (c) 2010-2016, Vladimir Agafonkin
+    Copyright (c) 2010-2011, CloudMade
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are
+    permitted provided that the following conditions are met:
+
+       1. Redistributions of source code must retain the above copyright notice, this list of
+          conditions and the following disclaimer.
+
+       2. Redistributions in binary form must reproduce the above copyright notice, this list
+          of conditions and the following disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#endregion
+
+using System;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Serves as the base for CRS that are global such that they cover the earth.
+/// </summary>
+public abstract class Earth : CoordinateReferenceSystem
+{
+    /// <summary>
+    /// Returns the distance, in meters, between two geographical coordinates.
+    /// </summary>
+    /// <param name="coordinate1">The first geographical coordinate.</param>
+    /// <param name="coordinate2">The second geographical coordinate.</param>
+    /// <returns>The distance between two geographical coordinates.</returns>
+    public override double Distance(GeoCoordinate coordinate1, GeoCoordinate coordinate2)
+    {
+        const double RadianConversionFactor = Math.PI / 180.0D;
+        const double R = 6378137;
+
+        double phi1 = coordinate1.Latitude * RadianConversionFactor;
+        double phi2 = coordinate2.Latitude * RadianConversionFactor;
+        double lambda1 = coordinate1.Longitude * RadianConversionFactor;
+        double lambda2 = coordinate2.Longitude * RadianConversionFactor;
+        double dPhi = phi2 - phi1;
+        double dLambda = lambda2 - lambda1;
+
+        double sinPhi = Math.Sin(dPhi / 2);
+        double sinLambda = Math.Sin(dLambda / 2);
+
+        double a = sinPhi * sinPhi +
+                   Math.Cos(phi1) * Math.Cos(phi2) *
+                   sinLambda * sinLambda;
+
+        double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+
+        return R * c;
+    }
+}

--- a/src/Gemstone.Numeric/Geo/GeoCoordinate.cs
+++ b/src/Gemstone.Numeric/Geo/GeoCoordinate.cs
@@ -1,0 +1,89 @@
+﻿//******************************************************************************************************
+//  GeoCoordinate.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Represents a location in the geographical coordinate system.
+/// </summary>
+public class GeoCoordinate
+{
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="GeoCoordinate"/> class.
+    /// </summary>
+    /// <param name="latitude">The latitude of the geographical coordinate.</param>
+    /// <param name="longitude">The longitude of the geographical coordinate.</param>
+    public GeoCoordinate(double latitude, double longitude)
+    {
+        Latitude = latitude;
+        Longitude = longitude;
+    }
+
+    #endregion
+
+    #region [ Properties ]
+
+    /// <summary>
+    /// Gets the latitude of the geographical coordinate.
+    /// </summary>
+    public double Latitude { get; private set; }
+
+    /// <summary>
+    /// Gets the longitude of the geographical coordinate.
+    /// </summary>
+    public double Longitude { get; private set; }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Calculates distance between this and another <see cref="GeoCoordinate"/> value.
+    /// Base on the <see cref="EPSG3857"/> reference system.
+    /// </summary>
+    /// <param name="other">Other <see cref="GeoCoordinate"/>.</param>
+    /// <returns>Distance between two <see cref="GeoCoordinate"/> values.</returns>
+    public double Distance(GeoCoordinate other)
+    {
+        CoordinateReferenceSystem referenceSystem = new EPSG3857();
+        return Distance(other, referenceSystem);
+    }
+
+    /// <summary>
+    /// Calculates distance between this and another <see cref="GeoCoordinate"/> value.
+    /// using the specified <see cref="CoordinateReferenceSystem"/>
+    /// </summary>
+    /// <param name="other">Other <see cref="GeoCoordinate"/>.</param>
+    /// <param name="referenceSystem">The <see cref="CoordinateReferenceSystem"/> used.</param>
+    /// <returns>Distance between two <see cref="GeoCoordinate"/> values.</returns>
+    public double Distance(GeoCoordinate other, CoordinateReferenceSystem referenceSystem)
+    {
+        return referenceSystem.Distance(this, other);
+    }
+
+    #endregion
+}

--- a/src/Gemstone.Numeric/Geo/IProjection.cs
+++ b/src/Gemstone.Numeric/Geo/IProjection.cs
@@ -1,0 +1,47 @@
+﻿//******************************************************************************************************
+//  IProjection.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using Gemstone.Numeric.Analysis;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Defines a map projection to translate geographical
+/// coordinates to points in an xy-coordinate system.
+/// </summary>
+public interface IProjection
+{
+    /// <summary>
+    /// Projects the given coordinates onto the xy-coordinate system.
+    /// </summary>
+    /// <param name="coordinate">The geographical coordinates to be projected.</param>
+    /// <returns>The given coordinates projected onto the xy-coordinate system.</returns>
+    Point Project(GeoCoordinate coordinate);
+
+    /// <summary>
+    /// Unprojects the given point to the geographical coordinate system.
+    /// </summary>
+    /// <param name="point">The point to be unprojected.</param>
+    /// <returns>The geographical coordinates of the given point.</returns>
+    GeoCoordinate Unproject(Point point);
+}

--- a/src/Gemstone.Numeric/Geo/NOTICE.txt
+++ b/src/Gemstone.Numeric/Geo/NOTICE.txt
@@ -1,0 +1,27 @@
+﻿Much of the code in this project, as noted in the header of the source file, was based
+heavily on the Leaflet open source Javascript library, which can be found at
+http://leafletjs.com/.
+
+Copyright (c) 2010-2016, Vladimir Agafonkin
+Copyright (c) 2010-2011, CloudMade
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list
+      of conditions and the following disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/Gemstone.Numeric/Geo/SphericalMercator.cs
+++ b/src/Gemstone.Numeric/Geo/SphericalMercator.cs
@@ -1,0 +1,106 @@
+﻿//******************************************************************************************************
+//  SphericalMercator.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+#region [ Contributor License Agreements ]
+
+/*
+    Copyright (c) 2010-2016, Vladimir Agafonkin
+    Copyright (c) 2010-2011, CloudMade
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are
+    permitted provided that the following conditions are met:
+
+       1. Redistributions of source code must retain the above copyright notice, this list of
+          conditions and the following disclaimer.
+
+       2. Redistributions in binary form must reproduce the above copyright notice, this list
+          of conditions and the following disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#endregion
+
+using System;
+using Gemstone.Numeric.Analysis;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Spherical Mercator projection; the most common projection for online maps.
+/// Assumes that Earth is a sphere. Used by the <c>EPSG:3857</c> CRS.
+/// </summary>
+public class SphericalMercator : IProjection
+{
+    /// <summary>
+    /// Radius of the Earth (meters).
+    /// </summary>
+    public const double R = 6378137;
+
+    /// <summary>
+    /// The maximum latitude.
+    /// </summary>
+    public const double MaxLatitude = 85.0511287798;
+
+    /// <summary>
+    /// Projects the given coordinates onto the xy-coordinate system.
+    /// </summary>
+    /// <param name="coordinate">The geographical coordinates to be projected.</param>
+    /// <returns>The given coordinates projected onto the xy-coordinate system.</returns>
+    public Point Project(GeoCoordinate coordinate)
+    {
+        const double RadianConversionFactor = Math.PI / 180;
+
+        double lat = Math.Max(Math.Min(MaxLatitude, coordinate.Latitude), -MaxLatitude);
+        double sin = Math.Sin(lat * RadianConversionFactor);
+        double x = R * coordinate.Longitude * RadianConversionFactor;
+        double y = R * Math.Log((1 + sin) / (1 - sin)) / 2;
+
+        return new Point(x, y);
+    }
+
+    /// <summary>
+    /// Unprojects the given point to the geographical coordinate system.
+    /// </summary>
+    /// <param name="point">The point to be unprojected.</param>
+    /// <returns>The geographical coordinates of the given point.</returns>
+    public GeoCoordinate Unproject(Point point)
+    {
+        const double DegreeConversionFactor = 180 / Math.PI;
+
+        double latitude = (2 * Math.Atan(Math.Exp(point.Y / R)) - (Math.PI / 2)) * DegreeConversionFactor;
+        double longitude = point.X * DegreeConversionFactor / R;
+
+        return new GeoCoordinate(latitude, longitude);
+    }
+}

--- a/src/Gemstone.Numeric/Geo/Transformation.cs
+++ b/src/Gemstone.Numeric/Geo/Transformation.cs
@@ -1,0 +1,121 @@
+﻿//******************************************************************************************************
+//  Transformation.cs - Gbtc
+//
+//  Copyright © 2016, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/20/2016 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+#region [ Contributor License Agreements ]
+
+/*
+    Copyright (c) 2010-2016, Vladimir Agafonkin
+    Copyright (c) 2010-2011, CloudMade
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are
+    permitted provided that the following conditions are met:
+
+       1. Redistributions of source code must retain the above copyright notice, this list of
+          conditions and the following disclaimer.
+
+       2. Redistributions in binary form must reproduce the above copyright notice, this list
+          of conditions and the following disclaimer in the documentation and/or other materials
+          provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#endregion
+
+using Gemstone.Numeric.Analysis;
+
+namespace Gemstone.Numeric.Geo;
+
+/// <summary>
+/// Represents a linear transformation over an xy-coordinate system.
+/// </summary>
+public class Transformation
+{
+    #region [ Members ]
+
+    // Fields
+    private readonly double m_xScale;
+    private readonly double m_xOffset;
+    private readonly double m_yScale;
+    private readonly double m_yOffset;
+
+    #endregion
+
+    #region [ Constructors ]
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="Transformation"/> class.
+    /// </summary>
+    /// <param name="xScale">The scale to be applied to the x-value of the point.</param>
+    /// <param name="xOffset">The offset to be applied to the x-value of the point.</param>
+    /// <param name="yScale">The scale to be applied to the y-value of the point.</param>
+    /// <param name="yOffset">The offset to be applied to the y-value of the point.</param>
+    public Transformation(double xScale, double xOffset, double yScale, double yOffset)
+    {
+        m_xScale = xScale;
+        m_xOffset = xOffset;
+        m_yScale = yScale;
+        m_yOffset = yOffset;
+    }
+
+    #endregion
+
+    #region [ Methods ]
+
+    /// <summary>
+    /// Transforms the given point to another location.
+    /// </summary>
+    /// <param name="point">The point to be transformed.</param>
+    /// <param name="scale">The scale to apply after the transformation.</param>
+    /// <returns>The transformed point.</returns>
+    public Point Transform(Point point, double scale = 1.0D)
+    {
+        double x = scale * (point.X * m_xScale + m_xOffset);
+        double y = scale * (point.Y * m_yScale + m_yOffset);
+        return new Point(x, y);
+    }
+
+    /// <summary>
+    /// Untransforms the given point to its original location.
+    /// </summary>
+    /// <param name="point">The transformed point.</param>
+    /// <param name="scale">The scale that was applied after the transformation.</param>
+    /// <returns>The original point.</returns>
+    public Point Untransform(Point point, double scale = 1.0D)
+    {
+        double x = (point.X / scale - m_xOffset) / m_xScale;
+        double y = (point.Y / scale - m_yOffset) / m_yScale;
+        return new Point(x, y);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Defines code to handle EPSG3857 Spherical Mercator Projection and associated transformations for map related work.